### PR TITLE
Add validate callback to ID argument in endpoint

### DIFF
--- a/disable-media-pages.php
+++ b/disable-media-pages.php
@@ -135,7 +135,13 @@ class DisableMediaPages {
         register_rest_route('disable-media-pages/v1', '/process/(?P<id>\d+)', [
             'methods' => 'POST',
             'callback' => [$this, 'rest_api_process_attachment'],
-            'args' => ['id'],
+            'args' => [
+                'id' => [
+                    'validate_callback' => function( $param ) {
+                        return is_numeric( $param );
+                    },
+                ],
+            ],
             'permission_callback' => function () {
                 return current_user_can('manage_options');
             },


### PR DESCRIPTION
I got these warnings in the log:

```
PHP Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in /data/wordpress/htdocs/wordpress/wp-includes/rest-api/class-wp-rest-server.php on line 1402
```

And later, in the stack trace:

```
PHP 16. array_intersect_key('id', array ('title' => 0, 'description' => 1, 'default' => 2, 'type' => 3, 'format' => 4, 'enum' => 5, 'items' => 6, 'properties' => 7, 'additionalProperties' => 8, 'patternProperties' => 9, 'minProperties' => 10, 'maxProperties' => 11, 'minimum' => 12, 'maximum' => 13, 'exclusiveMinimum' => 14, 'exclusiveMaximum' => 15, 'multipleOf' => 16, 'minLength' => 17, 'maxLength' => 18, 'pattern' => 19, 'minItems' => 20, 'maxItems' => 21, 'uniqueItems' => 22, 'anyOf' => 23, 'oneOf' => 24)) /data/wordpress/htdocs/wordpress/wp-includes/rest-api/class-wp-rest-server.php:1402
```

So it seemed to me that there's something wrong with the `id` argument in the `process` endpoint.

Based on the [docs](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#arguments) it seems that the argument items should have a key and a value. An empty array as value for the `id` key (`['id' => []]`) would apparently work as well, but might as well add a validation.